### PR TITLE
Fix for HTTPConnection error

### DIFF
--- a/disqusapi/__init__.py
+++ b/disqusapi/__init__.py
@@ -83,7 +83,7 @@ class Resource(object):
 
         if resource['method'] == 'GET':
             path = '%s?%s' % (path, urllib.urlencode(qs))
-            data = {}
+            data = ""
         else:
             data = urllib.urlencode(qs)
 


### PR DESCRIPTION
I get this error when calling any API method:

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Users/adammiskiewicz/virtualenvs/jess3_com/src/disqusapi/disqusapi/__init__.py", line 91, in __call__
    'User-Agent': 'disqus-python/%s' % __version__
  File "/usr/local/Cellar/python/2.7.1/lib/python2.7/httplib.py", line 941, in request
    self._send_request(method, url, body, headers)
  File "/usr/local/Cellar/python/2.7.1/lib/python2.7/httplib.py", line 975, in _send_request
    self.endheaders(body)
  File "/usr/local/Cellar/python/2.7.1/lib/python2.7/httplib.py", line 937, in endheaders
    self._send_output(message_body)
  File "/usr/local/Cellar/python/2.7.1/lib/python2.7/httplib.py", line 801, in _send_output
    self.send(message_body)
  File "/usr/local/Cellar/python/2.7.1/lib/python2.7/httplib.py", line 773, in send
    self.sock.sendall(data)
  File "/usr/local/Cellar/python/2.7.1/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
 TypeError: must be string or buffer, not dict
```

This commit fixes it.  You can't pass dicts to the request method for data - it expects a string
