### PR TITLE
Fork with Paginator fix pull request

### DIFF
--- a/disqusapi/__init__.py
+++ b/disqusapi/__init__.py
@@ -48,8 +48,8 @@ class Paginator(object):
         params = self.params.copy()
         num = 0
         more = True
-        results = self.endpoint(**params)
         while more and (not limit or num < limit):
+            results = self.endpoint(**params)
             for result in results:
                 if limit and num >= limit:
                     break


### PR DESCRIPTION
Hi, 

Currently in disqus-python 0.2.0 Paginator is not working. It never makes the second API call to fetch more items from DISQUS. I fixed this in my fork, please, pull it into your main fork and if possible, release it on pypi as this bug is a major thing I think.

Thanks,
Vitaliy Podoba

"fix Paginator loop, before it hanged looping over the same results list w/o making further API calls"
