### PR TITLE
Bugfix for signature and thread:link errors

### DIFF
--- a/disqusapi/__init__.py
+++ b/disqusapi/__init__.py
@@ -21,7 +21,9 @@ import uuid
 import warnings
 
 from disqusapi.paginator import Paginator
-from disqusapi.utils import get_normalized_request_string, get_mac_signature, get_body_hash
+from disqusapi.utils import (get_normalized_params,
+                             get_normalized_request_string, get_mac_signature,
+                             get_body_hash)
 
 __all__ = ['DisqusAPI', 'Paginator']
 
@@ -87,7 +89,7 @@ class Resource(object):
         # Handle undefined interfaces
         resource = self.interface
         for k in resource.get('required', []):
-            if not kwargs.get(k):
+            if k not in [ x.split(':')[0] for x in kwargs.keys() ]:
                 raise ValueError('Missing required argument: %s' % k)
 
         api = self.api
@@ -116,7 +118,7 @@ class Resource(object):
                 params.append((k, v))
 
         if resource['method'] == 'GET':
-            path = '%s?%s' % (path, urllib.urlencode(params))
+            path = '%s?%s' % (path, get_normalized_params(params))
 
         headers = {
             'User-Agent': 'disqus-python/%s' % __version__


### PR DESCRIPTION
Started playing with this lib to archive comments for my blog, and ended up having to make these tweaks to get things working.

Before these tweaks, request signatures seemed to get rejected constantly. Seems like the parameter ordering was an issue.

Also, I couldn't use the thread:link param to fetch a thread for a blog post by URL.
