### PR TITLE
Added socket timeout to HTTPSConnection

### DIFF
--- a/disqusapi/__init__.py
+++ b/disqusapi/__init__.py
@@ -160,14 +160,14 @@ class DisqusAPI(Resource):
         'json': lambda x: simplejson.loads(x),
     }
 
-    def __init__(self, secret_key=None, public_key=None, format='json', version='3.0', **kwargs):
+    def __init__(self, secret_key=None, public_key=None, format='json', version='3.0', timeout=None, **kwargs):
         self.secret_key = secret_key
         self.public_key = public_key
         if not public_key:
             warnings.warn('You should pass ``public_key`` in addition to your secret key.')
         self.format = format
         self.version = version
-        self.timeout = kwargs.get('timeout', socket.getdefaulttimeout())
+        self.timeout = timeout or socket.getdefaulttimeout()
         super(DisqusAPI, self).__init__(self)
 
     def _request(self, **kwargs):

--- a/disqusapi/tests.py
+++ b/disqusapi/tests.py
@@ -1,6 +1,7 @@
 import mock
 import os
 import unittest
+import socket
 
 import disqusapi
 
@@ -59,6 +60,8 @@ class DisqusAPITest(unittest.TestCase):
         self.assertEquals(api.version, '3.1')
 
     def test_setTimeout(self):
+        api = disqusapi.DisqusAPI()
+        self.assertEquals(api.timeout, socket.getdefaulttimeout())
         api = disqusapi.DisqusAPI(timeout=30)
         self.assertEquals(api.timeout, 30)
         api.setTimeout(60)


### PR DESCRIPTION
Without the timeout, disqus-python can hang on a slow connection or slow API. If not set, the global default timeout setting is used, which can also be set with `socket.setdefaulttimeout(30)` (which is how we got around the `SSLError: The read operation timed out` exception thrown on slow internet days)

Added tests for the setter, but there are no tests for what happens when the connection is bad, which is probably why this particular issue was never noticed.
