### PR TITLE
Add some missing interfaces; alter handling of missing `public_key`

### DIFF
--- a/disqusapi/__init__.py
+++ b/disqusapi/__init__.py
@@ -176,7 +176,8 @@ class DisqusAPI(Resource):
         self.secret_key = secret_key
         self.public_key = public_key
         if not public_key and not secret_key:
-            warnings.warn("You should at least pass ``public_key`` if you don't pass your secret key.")
+            warnings.warn("You should at least pass ``public_key`` if you "
+                          "don't pass your secret key.")
         self.format = format
         self.version = version
         self.timeout = timeout or socket.getdefaulttimeout()

--- a/disqusapi/__init__.py
+++ b/disqusapi/__init__.py
@@ -175,8 +175,8 @@ class DisqusAPI(Resource):
                  timeout=None, **kwargs):
         self.secret_key = secret_key
         self.public_key = public_key
-        if not public_key:
-            warnings.warn('You should pass ``public_key`` in addition to your secret key.')
+        if not public_key and not secret_key:
+            warnings.warn("You should at least pass ``public_key`` if you don't pass your secret key.")
         self.format = format
         self.version = version
         self.timeout = timeout or socket.getdefaulttimeout()

--- a/disqusapi/interfaces.json
+++ b/disqusapi/interfaces.json
@@ -309,7 +309,7 @@
     "update": {
       "required": [
         "post",
-       "message"
+        "message"
       ],
       "method": "POST",
       "formats": [

--- a/disqusapi/interfaces.json
+++ b/disqusapi/interfaces.json
@@ -571,6 +571,17 @@
     }
   },
   "forums": {
+    "addModerator": {
+      "required": [
+        "forum",
+        "user"
+      ],
+      "method": "POST",
+      "formats": [
+        "json",
+        "jsonp"
+      ]
+    },
     "create": {
       "required": [
         "website",
@@ -650,6 +661,16 @@
         "forum"
       ],
       "method": "GET",
+      "formats": [
+        "json",
+        "jsonp"
+      ]
+    },
+    "removeModerator": {
+      "required": [
+        "moderator"
+      ],
+      "method": "POST",
       "formats": [
         "json",
         "jsonp"

--- a/disqusapi/interfaces.json
+++ b/disqusapi/interfaces.json
@@ -305,6 +305,17 @@
         "json",
         "jsonp"
       ]
+    },
+    "update": {
+      "required": [
+        "post",
+       "message"
+      ],
+      "method": "POST",
+      "formats": [
+        "json",
+        "jsonp"
+      ]
     }
   },
   "blacklists": {


### PR DESCRIPTION
Add three endpoints missing from interfaces.json added (posts.update, forums.addModerator and forums.removeModerator);

Somewhat cosmetic change: Some API calls (notably posts.create with certain args like ip_address) will not work as expected if both public_key and secret_key are passed, so alter the check in `disqusapi.DisqusAPI.__init__()` so that it doesn't complain when only secret key is provided.
