### PR TITLE
Set Content-Type header when making a POST request.

### DIFF
--- a/disqusapi/__init__.py
+++ b/disqusapi/__init__.py
@@ -184,6 +184,7 @@ class Resource(object):
             data = ''
         else:
             data = urllib.urlencode(params)
+            headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
         conn = httplib.HTTPSConnection(HOST, timeout=api.timeout)
         conn.request(method, path, data, headers)


### PR DESCRIPTION
Django 1.5 requires that Content-Type be set on a POST request, otherwise params are not available in request.POST

https://docs.djangoproject.com/en/1.10/releases/1.5/#non-form-data-in-http-requests